### PR TITLE
Fix SWR mutate calls to disable revalidation

### DIFF
--- a/lab4/src/hooks/useTodos.ts
+++ b/lab4/src/hooks/useTodos.ts
@@ -14,7 +14,7 @@ export const useTodos = () => {
   });
 
   const deleteTodo = async (idToDelete: string) => {
-    mutate(data?.filter((todo) => todo._id !== idToDelete));
+    mutate(data?.filter((todo) => todo._id !== idToDelete), false);
     try {
       await fetch(`${url}/${idToDelete}`, { method: "DELETE" });
       toast.success("Todo deleted successfully");
@@ -28,7 +28,7 @@ export const useTodos = () => {
 
   const addTodo = async (title: string) => {
     const newTodo = { title, completed: false };
-    mutate([...(data || []), newTodo]);
+    mutate([...(data || []), newTodo], false);
     try {
       await fetch(url, {
         method: "POST",


### PR DESCRIPTION
Adds 'false' as the second argument to SWR's mutate function in addTodo and deleteTodo to prevent automatic revalidation after local data updates.